### PR TITLE
adds Maven infrastructure and source files to package and distribute project as a Docker Image

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -80,3 +80,18 @@ generator:
     - "root_package": "com.myorg"
     - "service_class_name": "MyService"
 
+---
+kind: "operation"
+client: "atomist"
+editor:
+  name: "atomist-rugs.spring-boot-editors.AddDockerMavenBuild"
+  group: "atomist-rugs"
+  artifact: "spring-boot-editors"
+  version: "0.5.3"
+  origin:
+    repo: "https://github.com/atomist-rugs/spring-boot-editors.git"
+    branch: "6b4e1db16848b1c8ae5186e5f65e3907f333ff44"
+    sha: "6b4e1db"
+  parameters:
+    - "base_docker_repository": "http://atomist.jfrog.io"
+

--- a/README.md
+++ b/README.md
@@ -38,3 +38,20 @@ The following Atomist editors are available for this project:
 ---
 Created on 2017-02-24 by Atomist.
 Need Help? <a href="https://join.atomist.com/">Join our Slack community</a>.
+
+## Create a docker container
+
+You can now build, package and run this microservice using Docker.
+
+Now you can build your docker image by entering from a terminal where
+you have access to Docker, execute the following command:
+
+```sh
+$ ./mvnw clean package docker:build
+```
+
+Even push it to a repository of your choice:
+
+```sh
+$ ./mvnw clean package docker:build -DpushImage
+```

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,56 @@
 					</execution>
 				</executions>
 			</plugin>
-		</plugins>
+			<plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+            </plugin>
+        	<plugin>
+				<groupId>com.spotify</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<version>0.4.11</version>
+				<configuration>
+					<imageName>http://atomist.jfrog.io/${project.name}</imageName>
+					<dockerDirectory>src/main/docker</dockerDirectory>
+					<resources>
+						<resource>
+							<targetPath>/</targetPath>
+							<directory>${project.build.directory}</directory>
+							<include>${project.build.finalName}.jar</include>
+						</resource>
+					</resources>
+					<useConfigFile>true</useConfigFile>
+					<imageTags>
+						<imageTag>${project.version}</imageTag>
+					</imageTags>
+				</configuration>
+			</plugin>
+        	<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.10</version>
+				<executions>
+					<execution>
+						<id>unpack</id>
+						<phase>package</phase>
+						<goals>
+							<goal>unpack</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>${project.groupId}</groupId>
+									<artifactId>${project.artifactId}</artifactId>
+									<version>${project.version}</version>
+									<type>jar</type>
+									<outputDirectory>${project.build.directory}/docker</outputDirectory>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+        </plugins>
 	</build>
 
 </project>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM java:8-jre
+
+# First copy over the static Spring Boot launcher classes and all the project
+# dependencies
+COPY org /opt/build/org
+COPY BOOT-INF/lib /opt/build/BOOT-INF/lib
+
+# Copy over the changing project classes
+COPY META-INF /opt/build/META-INF
+COPY BOOT-INF/classes /opt/build/BOOT-INF/classes
+
+WORKDIR /opt/build/
+
+EXPOSE 8080
+
+CMD ["java", "-Xmx1g", "org.springframework.boot.loader.JarLauncher"]


### PR DESCRIPTION
Created by Atomist Editor `atomist-rugs.spring-boot-editors.AddDockerMavenBuild`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "atomist-rugs.spring-boot-editors.AddDockerMavenBuild"
  group: "atomist-rugs"
  artifact: "spring-boot-editors"
  version: "0.5.3"
  origin:
    repo: "https://github.com/atomist-rugs/spring-boot-editors.git"
    branch: "6b4e1db16848b1c8ae5186e5f65e3907f333ff44"
    sha: "6b4e1db"
  parameters:
    - "base_docker_repository": "http://atomist.jfrog.io"

```